### PR TITLE
[#101] 修复更新rpk过程中获取到旧版本AppInfo的情况

### DIFF
--- a/core/runtime/android/runtime/src/main/java/org/hapjs/cache/Cache.java
+++ b/core/runtime/android/runtime/src/main/java/org/hapjs/cache/Cache.java
@@ -224,12 +224,22 @@ public class Cache {
 
     public synchronized AppInfo getAppInfo(boolean useCache) {
         if (mAppInfo == null || !useCache) {
-            return getAppInfo();
+            return getAppInfoInner(useCache);
         }
         return mAppInfo;
     }
 
-    public synchronized AppInfo getAppInfo() {
+    public AppInfo getAppInfo() {
+        return getAppInfoInner(true);
+    }
+
+    /**
+     * Get latest AppInfo from file or network.
+     *
+     * @param useCache
+     *      If <code>true</code>, use cache when manifest file do not exist.
+     */
+    private synchronized AppInfo getAppInfoInner(boolean useCache) {
         File file = getManifestFile();
         if (file.exists()) {
             long lastManifestUpdateTime = file.lastModified();
@@ -243,7 +253,7 @@ public class Cache {
                 }
             }
         } else {
-            if (mAppInfo == null) {
+            if (mAppInfo == null || !useCache) {
                 mAppInfo = AppInfoProviderHolder.get().create(mContext, mPackageName);
             }
         }

--- a/core/runtime/android/runtime/src/main/java/org/hapjs/render/RootView.java
+++ b/core/runtime/android/runtime/src/main/java/org/hapjs/render/RootView.java
@@ -817,6 +817,7 @@ public class RootView extends FrameLayout
                             protected LoadResult doInBackground() {
                                 RuntimeLogManager.getDefault()
                                         .logAsyncThreadTaskStart(mPackage, "loadAppInfo");
+                                Log.i(TAG, "loadAppInfo " + String.valueOf(request.getPackage()));
                                 ApplicationContext appContext =
                                         HapEngine.getInstance(request.getPackage())
                                                 .getApplicationContext();


### PR DESCRIPTION
在rpk更新过程中，如果已经删除旧版本manifest，而尚未下载完成新版本manifest，就可能获取AppInfo就会获取到老版本。
（ps：前提是内存中mAppInfo有值）

Change-Id: I6232343fa19b5bb560b2d6b7ecbdbaf5036dd409