### PR TITLE
调试器的androidx版本依赖导致build break

### DIFF
--- a/debug/shell/android/build.gradle
+++ b/debug/shell/android/build.gradle
@@ -20,9 +20,9 @@ buildscript {
     }
 }
 
-apply from: 'version.gradle', to: rootProject
 apply from: '../../../core/runtime/android/version.gradle', to: rootProject
 apply from: '../../../core/runtime/android/config.gradle', to: rootProject
+apply from: 'version.gradle', to: rootProject
 
 allprojects {
     repositories {


### PR DESCRIPTION
fix #183