### PR TITLE
[#195] 组件背景刷新时CSSBackgroundDrawable中默认的初始背景被清空

### DIFF
--- a/core/runtime/android/runtime/src/main/java/org/hapjs/component/view/drawable/CSSBackgroundDrawable.java
+++ b/core/runtime/android/runtime/src/main/java/org/hapjs/component/view/drawable/CSSBackgroundDrawable.java
@@ -164,6 +164,10 @@ public class CSSBackgroundDrawable extends Drawable {
         invalidateSelf();
     }
 
+    public LayerDrawable getLayerDrawable() {
+        return mLayerDrawable;
+    }
+
     public void setRadiusPercent(float radiusPercent) {
         if (!FloatUtil.floatsEqual(mBorderRadiusPercent, radiusPercent)) {
             mBorderRadiusPercent = radiusPercent;


### PR DESCRIPTION
Change-Id: Ifba4aa1681561b41a7bad06585a356849e5581e5
Signed-off-by: xiaopengfei <pengfei.xiao@vivo.com>