### PR TITLE
[#195] 组件背景刷新时CSSBackgroundDrawable中默认的初始背景被清空

### DIFF
--- a/core/runtime/android/runtime/src/main/java/org/hapjs/component/ComponentBackgroundComposer.java
+++ b/core/runtime/android/runtime/src/main/java/org/hapjs/component/ComponentBackgroundComposer.java
@@ -51,6 +51,7 @@ public class ComponentBackgroundComposer {
 
     private Drawable mGradientDrawable;
     private Drawable mImageDrawable;
+    private Drawable mOriginalDrawable;
 
     public ComponentBackgroundComposer(@NonNull Component component) {
         mComponent = component;
@@ -279,6 +280,14 @@ public class ComponentBackgroundComposer {
             Drawable[] tmp = new Drawable[drawables.size()];
             LayerDrawable layerDrawable = new LayerDrawable(drawables.toArray(tmp));
             mBackgroundDrawable.setLayerDrawable(layerDrawable);
+        } else if (mOriginalDrawable != null) {
+            LayerDrawable layerDrawable = mBackgroundDrawable.getLayerDrawable();
+            if (layerDrawable != null && layerDrawable.getNumberOfLayers() == 1
+                    && layerDrawable.getDrawable(0) == mOriginalDrawable) {
+                // 正常情况，只有一层且该层是初始背景，无须处理
+            } else {
+                mBackgroundDrawable.setLayerDrawable(new LayerDrawable(new Drawable[]{mOriginalDrawable}));
+            }
         } else {
             mBackgroundDrawable.setLayerDrawable(null);
         }
@@ -401,7 +410,8 @@ public class ComponentBackgroundComposer {
                 || mComponent.getHostView().getBackground() instanceof CSSBackgroundDrawable) {
             return null;
         }
-        return mComponent.getHostView().getBackground();
+        mOriginalDrawable = mComponent.getHostView().getBackground();
+        return mOriginalDrawable;
     }
 
     private static class BackgroundHolder

--- a/core/runtime/android/runtime/src/main/java/org/hapjs/component/view/drawable/CSSBackgroundDrawable.java
+++ b/core/runtime/android/runtime/src/main/java/org/hapjs/component/view/drawable/CSSBackgroundDrawable.java
@@ -164,6 +164,10 @@ public class CSSBackgroundDrawable extends Drawable {
         invalidateSelf();
     }
 
+    public LayerDrawable getLayerDrawable() {
+        return mLayerDrawable;
+    }
+
     public void setRadiusPercent(float radiusPercent) {
         if (!FloatUtil.floatsEqual(mBorderRadiusPercent, radiusPercent)) {
             mBorderRadiusPercent = radiusPercent;


### PR DESCRIPTION
Change-Id: Ifba4aa1681561b41a7bad06585a356849e5581e5
Signed-off-by: xiaopengfei <pengfei.xiao@vivo.com>