### PR TITLE
增加Github Action可以自动构建和发布：框架预览版、调试器和对应的代码。

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,90 @@
+name: Hapjs CI
+
+# 触发器
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      versionTag:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: gengjiawen/android-ndk:qa-2020-07-31
+    steps:
+      - uses: actions/checkout@v2
+      # 打包预览版
+      - name: Build mockup
+        id: build_mockup
+        run: |
+          cd ./mockup/platform/android
+          ./gradlew assembleRelease -DappVersionTag=${{ inputs.versionTag }}
+          echo `pwd`
+          echo "rename apk"
+          echo `ls $GITHUB_WORKSPACE/mockup/platform/android/app/build/outputs/apk/phone/release`
+      # 打包调试器
+      - name: Build debugger
+        id: build_debugger
+        run: |
+          cd $GITHUB_WORKSPACE
+          cd ./debug/shell/android
+          ./gradlew assembleRelease -PdebugMode=false -DappVersionTag=${{ inputs.versionTag }}
+          echo `pwd`
+          echo "rename apk"
+          echo `ls $GITHUB_WORKSPACE/debug/shell/android/app/build/outputs/apk/release`
+      # 创建release
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ inputs.versionTag }}
+          release_name: Release ${{ inputs.versionTag }}
+          draft: false
+          prerelease: false
+
+        # 获取apk版本号
+      - name: Get Version Name
+        uses: actions/github-script@v3
+        id: get-version
+        with:
+          script: |
+            const str=process.env.GITHUB_REF;
+            return str.substring(str.indexOf("v"));
+          result-encoding: string
+      # 上传到release的资源——调试器
+      - name: Upload Debugger Release Asset
+        id: upload-debugger-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # 上传网址，无需改动
+          asset_path: ./debug/shell/android/app/build/outputs/apk/release/app-release.apk # 上传路径
+          asset_name: hapjs_debugger_${{steps.get-version.outputs.result}}.apk # 资源名
+          asset_content_type: application/vnd.android.package-archiv #资源类型
+      # 上传到release的资源——预览版
+      - name: Upload mockup Release Asset
+        id: upload-mockup-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # 上传网址，无需改动
+          asset_path: ./mockup/platform/android/app/build/outputs/apk/phone/release/app-phone-release.apk # 上传路径
+          asset_name: hapjs_platform_preview_release_${{steps.get-version.outputs.result}}.apk # 资源名
+          asset_content_type: application/vnd.android.package-archiv #资源类型
+     # 存档打包的文件
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: ./debug/shell/android/app/build/outputs/mapping/release
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: ./mockup/platform/android/app/build/outputs/mapping/phone/release


### PR DESCRIPTION
手动触发的Github Action，可以用来标准化发包的过程，效果如下

![image](https://user-images.githubusercontent.com/6316209/184833622-f715b74b-b566-4caf-810a-1d6c2ea5b8d1.png)
