### PR TITLE
[update]更新hapjs CI action，对调试器和预览版apk重命名，并且release出mapping文件。

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -21,9 +21,6 @@ jobs:
         run: |
           cd ./mockup/platform/android
           ./gradlew assembleRelease -DappVersionTag=${{ inputs.versionTag }}
-          echo `pwd`
-          echo "rename apk"
-          echo `ls $GITHUB_WORKSPACE/mockup/platform/android/app/build/outputs/apk/phone/release`
       # 打包调试器
       - name: Build debugger
         id: build_debugger
@@ -31,9 +28,6 @@ jobs:
           cd $GITHUB_WORKSPACE
           cd ./debug/shell/android
           ./gradlew assembleRelease -PdebugMode=false -DappVersionTag=${{ inputs.versionTag }}
-          echo `pwd`
-          echo "rename apk"
-          echo `ls $GITHUB_WORKSPACE/debug/shell/android/app/build/outputs/apk/release`
       # 创建release
       - name: Create Release
         id: create_release
@@ -45,46 +39,47 @@ jobs:
           release_name: Release ${{ inputs.versionTag }}
           draft: false
           prerelease: false
-
-        # 获取apk版本号
-      - name: Get Version Name
-        uses: actions/github-script@v3
-        id: get-version
-        with:
-          script: |
-            const str=process.env.GITHUB_REF;
-            return str.substring(str.indexOf("v"));
-          result-encoding: string
-      # 上传到release的资源——调试器
+      # 上传到release的资源——调试器apk
       - name: Upload Debugger Release Asset
         id: upload-debugger-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # 上传网址，无需改动
-          asset_path: ./debug/shell/android/app/build/outputs/apk/release/app-release.apk # 上传路径
-          asset_name: hapjs_debugger_${{steps.get-version.outputs.result}}.apk # 资源名
-          asset_content_type: application/vnd.android.package-archiv #资源类型
-      # 上传到release的资源——预览版
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./debug/shell/android/app/build/outputs/apk/release/app-release.apk
+          asset_name: hapjs_debugger_v${{ inputs.versionTag }}.apk
+          asset_content_type: application/vnd.android.package-archiv
+      # 上传到release的资源——预览版apk
       - name: Upload mockup Release Asset
         id: upload-mockup-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # 上传网址，无需改动
-          asset_path: ./mockup/platform/android/app/build/outputs/apk/phone/release/app-phone-release.apk # 上传路径
-          asset_name: hapjs_platform_preview_release_${{steps.get-version.outputs.result}}.apk # 资源名
-          asset_content_type: application/vnd.android.package-archiv #资源类型
-     # 存档打包的文件
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mockup/platform/android/app/build/outputs/apk/phone/release/app-phone-release.apk
+          asset_name: hapjs_platform_preview_release_v${{ inputs.versionTag }}.apk
+          asset_content_type: application/vnd.android.package-archiv
+      # 上传到release的资源——调试器mapping文件
+      - name: Upload debugger Release Asset
+        id: upload-debugger-mapping-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: build
-          path: ./debug/shell/android/app/build/outputs/mapping/release
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./debug/shell/android/app/build/outputs/mapping/release/mapping.txt
+          asset_name: hapjs_debugger_v${{ inputs.versionTag }}_mapping.txt
+          asset_content_type: text/plain
+      # 上传到release的资源——预览版mapping文件
+      - name: Upload mockup Release Asset
+        id: upload-mockup-mapping-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: build
-          path: ./mockup/platform/android/app/build/outputs/mapping/phone/release
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mockup/platform/android/app/build/outputs/mapping/phone/release/mapping.txt
+          asset_name: hapjs_platform_preview_release_v${{ inputs.versionTag }}_mapping.txt
+          asset_content_type: text/plain


### PR DESCRIPTION
更新hapjs CI action：1. 重命名调试器和预览版apk文件；2. 新增将mapping文件release出来。