### PR TITLE
[#208]:按照Android要求，从Android 10开始不可向第三方快应用提供SN

### DIFF
--- a/core/runtime/android/features/src/main/java/org/hapjs/features/Device.java
+++ b/core/runtime/android/features/src/main/java/org/hapjs/features/Device.java
@@ -420,7 +420,10 @@ public class Device extends FeatureExtension {
 
     private Response getSerial(Request request) throws JSONException {
         String serial;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            //Starting with Android API level 29(Q),third part App not allowed to get SN.
+            return new Response(Response.CODE_GENERIC_ERROR, "getSerial fail，not allowed to get SN starting with Android Q");
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             try {
                 serial = Build.getSerial();
             } catch (SecurityException e) {


### PR DESCRIPTION
Change-Id: I3f2d5c6b76ec59c3ab28a1c38517614f2040a79f
Signed-off-by: xiaomin <xiaomin@vivo.com>