### PR TITLE
[#387]适配1100打包，更新hapjs CI workflow

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -20,7 +20,7 @@ jobs:
         id: build_mockup
         run: |
           cd ./mockup/platform/android
-          ./gradlew assembleRelease -DappVersionTag=${{ inputs.versionTag }}
+          ./gradlew assemblePhoneRelease -DappVersionTag=${{ inputs.versionTag }}
       # 打包调试器
       - name: Build debugger
         id: build_debugger


### PR DESCRIPTION
fix #387 为了适配1100打包发版，将hapjs CI脚本assembleRelease 更新为 assemblePhoneRelease