### PR TITLE
[#454]图标更新接口增加isOpIconUpdate（是否为运营图标更新）参数以及新增updateShortcutsAsync方法由厂商自己实现，实现客制化需求

### DIFF
--- a/core/runtime/android/runtime/src/main/java/org/hapjs/common/utils/ShortcutManager.java
+++ b/core/runtime/android/runtime/src/main/java/org/hapjs/common/utils/ShortcutManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the hapjs-platform Project Contributors
+ * Copyright (c) 2021-present, the hapjs-platform Project Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -247,21 +247,21 @@ public class ShortcutManager {
     }
 
     public static boolean update(Context context, String pkg, String appName, Uri iconUri) {
-        return update(context, pkg, "", appName, iconUri);
+        return update(context, pkg, "", appName, iconUri, false);
     }
 
-    public static boolean update(
-            Context context, String pkg, String path, String appName, Uri iconUri) {
+    public static boolean update(Context context, String pkg, String path, String appName, Uri iconUri,
+                                 boolean isOpIconUpdate) {
         Bitmap icon = IconUtils.getIconBitmap(context, iconUri);
         if (icon == null) {
             return false;
         }
-        return update(context, pkg, path, "", appName, icon);
+        return update(context, pkg, path, "", appName, icon, isOpIconUpdate);
     }
 
-    public static boolean update(
-            Context context, String pkg, String path, String params, String appName, Bitmap icon) {
-        return IMPL.updateShortcut(context, pkg, path, params, appName, icon);
+    public static boolean update(Context context, String pkg, String path, String params, String appName,
+                                 Bitmap icon, boolean isOpIconUpdate) {
+        return IMPL.updateShortcut(context, pkg, path, params, appName, icon, isOpIconUpdate);
     }
 
     public static boolean uninstall(Context context, String pkg, String appName) {

--- a/core/runtime/android/runtime/src/main/java/org/hapjs/system/DefaultSysOpProviderImpl.java
+++ b/core/runtime/android/runtime/src/main/java/org/hapjs/system/DefaultSysOpProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, the hapjs-platform Project Contributors
+ * Copyright (c) 2021-present, the hapjs-platform Project Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -89,8 +89,8 @@ public class DefaultSysOpProviderImpl implements SysOpProvider {
     }
 
     @Override
-    public boolean updateShortcut(
-            Context context, String pkg, String path, String params, String appName, Bitmap icon) {
+    public boolean updateShortcut(Context context, String pkg, String path, String params, String appName,
+                                  Bitmap icon, boolean isOpIconUpdate) {
         boolean result = false;
         if (Build.VERSION.SDK_INT >= 26) {
             result = updateShortcutAboveOreo(context, pkg, path, appName, icon);

--- a/core/runtime/android/runtime/src/main/java/org/hapjs/system/SysOpProvider.java
+++ b/core/runtime/android/runtime/src/main/java/org/hapjs/system/SysOpProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, the hapjs-platform Project Contributors
+ * Copyright (c) 2021-present, the hapjs-platform Project Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,8 +45,8 @@ public interface SysOpProvider {
 
     boolean hasShortcutInstalled(Context context, String pkg, String path);
 
-    boolean updateShortcut(
-            Context context, String pkg, String path, String params, String appName, Bitmap icon);
+    boolean updateShortcut(Context context, String pkg, String path, String params, String appName,
+                           Bitmap icon, boolean isOpIconUpdate);
 
     boolean uninstallShortcut(Context context, String pkg, String appName);
 

--- a/platform/platform/android/platform/src/main/java/org/hapjs/PlatformRuntime.java
+++ b/platform/platform/android/platform/src/main/java/org/hapjs/PlatformRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, the hapjs-platform Project Contributors
+ * Copyright (c) 2021-present, the hapjs-platform Project Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -139,7 +139,7 @@ public class PlatformRuntime extends Runtime implements Application.ActivityLife
                                     Log.e(TAG, "expected a non-null appInfo.");
                                     return;
                                 }
-                                ShortcutUtils.updateShortcutAsync(mContext, pkg);
+                                updateShortcutAsync(mContext, false, pkg);
                                 sendPackageChangeBroadcast(pkg,
                                         CardConstants.ACTION_PACKAGE_PACKAGE_ADDED);
                                 InstalledSubpackageManager.getInstance().clearOutdatedSubpackages(
@@ -152,7 +152,7 @@ public class PlatformRuntime extends Runtime implements Application.ActivityLife
                                     Log.e(TAG, "expected a non-null appInfo.");
                                     return;
                                 }
-                                ShortcutUtils.updateShortcutAsync(mContext, pkg);
+                                updateShortcutAsync(mContext, false, pkg);
                                 sendPackageChangeBroadcast(pkg,
                                         CardConstants.ACTION_PACKAGE_PACKAGE_UPDATED);
                                 InstalledSubpackageManager.getInstance().clearOutdatedSubpackages(
@@ -186,12 +186,21 @@ public class PlatformRuntime extends Runtime implements Application.ActivityLife
                         new Runnable() {
                             @Override
                             public void run() {
-                                ShortcutUtils.updateAllShortcutsAsync(mContext);
+                                updateShortcutAsync(mContext, true, null);
                             }
                         },
                         10 * 1000);
 
         InstallFileFlagManager.clearAllFlags(mContext);
+    }
+
+    //新增方法，由厂商自己实现
+    protected void updateShortcutAsync(Context context, boolean isAllShortcut, String packageName) {
+        if (isAllShortcut) {
+            ShortcutUtils.updateAllShortcutsAsync(context);
+        } else if (!TextUtils.isEmpty(packageName)) {
+            ShortcutUtils.updateShortcutAsync(context, packageName);
+        }
     }
 
     private void sendPackageChangeBroadcast(String pkg, String action) {

--- a/platform/platform/android/platform/src/main/java/org/hapjs/system/PlatformSysOpProviderImpl.java
+++ b/platform/platform/android/platform/src/main/java/org/hapjs/system/PlatformSysOpProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the hapjs-platform Project Contributors
+ * Copyright (c) 2021-present, the hapjs-platform Project Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -30,9 +30,9 @@ public class PlatformSysOpProviderImpl extends DefaultSysOpProviderImpl {
     }
 
     @Override
-    public boolean updateShortcut(
-            Context context, String pkg, String path, String params, String appName, Bitmap icon) {
-        boolean result = super.updateShortcut(context, pkg, path, params, appName, icon);
+    public boolean updateShortcut(Context context, String pkg, String path, String params, String appName,
+                                  Bitmap icon, boolean isOpIconUpdate) {
+        boolean result = super.updateShortcut(context, pkg, path, params, appName, icon, isOpIconUpdate);
         result = ShortcutParamsHelper.updateShortParams(context, pkg, path, params) || result;
         return result;
     }


### PR DESCRIPTION
fix #454 